### PR TITLE
Test on Python 3.10-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.10"
+  - "3.10-dev"
   - "3.9"
   - "3.8"
   - "3.7"


### PR DESCRIPTION
Travis CI hasn't yet updated to add `"3.10"` (tracking issue: https://travis-ci.community/t/add-python-3-10/12220) but we can test on the nightly build `"3.10-dev"` in the meantime.